### PR TITLE
docs: fix typo

### DIFF
--- a/sections/advanced.md
+++ b/sections/advanced.md
@@ -89,7 +89,7 @@ pre-commit installed at .git/hooks/commit-msg
 - [pre-merge-commit](#pre-merge-commit)
 - [pre-push](#pre-push)
 - [pre-rebase](#pre-rebase)
-- [prepare-comit-msg](#prepare-commit-msg)
+- [prepare-commit-msg](#prepare-commit-msg)
 
 ### commit-msg
 


### PR DESCRIPTION
Added missing `m` in the word `comit`.